### PR TITLE
Add colorblind mode with blue/gold palette

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,10 +41,16 @@ compile-dev:
 	@mv client/chrome/manifest.dev.json client/chrome/manifest.json
 	@cp client/common/client.js client/chrome/client.js
 	@cp client/common/background.js client/chrome/background.js
+	@cp client/common/client.css client/chrome/client.css
+	@cp client/common/popup.html client/chrome/popup.html
 	@cp client/common/client.js client/firefox/data/client.js
 	@cp client/common/background.js client/firefox/data/background.js
+	@cp client/common/client.css client/firefox/data/client.css
+	@cp client/common/popup.html client/firefox/data/popup.html
 	@cp client/common/client.js client/safari/WebExtension/client.js
 	@cp client/common/background.js client/safari/WebExtension/background.js
+	@cp client/common/client.css client/safari/WebExtension/client.css
+	@cp client/common/popup.html client/safari/WebExtension/popup.html
 
 compile-prod:
 	@coffee -c client/common/client.coffee
@@ -54,10 +60,16 @@ compile-prod:
 	@mv client/chrome/manifest.prod.json client/chrome/manifest.json
 	@cp client/common/client.js client/chrome/client.js
 	@cp client/common/background.js client/chrome/background.js
+	@cp client/common/client.css client/chrome/client.css
+	@cp client/common/popup.html client/chrome/popup.html
 	@cp client/common/client.js client/firefox/data/client.js
 	@cp client/common/background.js client/firefox/data/background.js
+	@cp client/common/client.css client/firefox/data/client.css
+	@cp client/common/popup.html client/firefox/data/popup.html
 	@cp client/common/client.js client/safari/WebExtension/client.js
 	@cp client/common/background.js client/safari/WebExtension/background.js
+	@cp client/common/client.css client/safari/WebExtension/client.css
+	@cp client/common/popup.html client/safari/WebExtension/popup.html
 
 renew:
 	sudo /etc/init.d/haproxy stop

--- a/client/chrome/background.js
+++ b/client/chrome/background.js
@@ -58,6 +58,22 @@
           });
         });
         return true;
+      case 'getColorblind':
+        storage.get(['hs_colorblind'], function(data) {
+          return sendResponse({
+            colorblind: !!(data != null ? data.hs_colorblind : void 0)
+          });
+        });
+        return true;
+      case 'setColorblind':
+        storage.set({
+          hs_colorblind: !!request.enabled
+        }, function() {
+          return sendResponse({
+            success: true
+          });
+        });
+        return true;
     }
   };
 

--- a/client/chrome/client.css
+++ b/client/chrome/client.css
@@ -190,3 +190,86 @@
         #C2483B 84%
     );
 }
+
+/* ========================== */
+/* = Colorblind Mode         = */
+/* ========================== */
+
+.HS-colorblind .HS-rater-button.HS-rater-friend {
+    background-color: #2B6CB0;
+    background-image: -webkit-gradient(
+        linear,
+        left bottom,
+        left top,
+        color-stop(0.16, #2563A8),
+        color-stop(0.84, #2B6CB0)
+    );
+    background-image: -moz-linear-gradient(
+        center bottom,
+        #2563A8 16%,
+        #2B6CB0 84%
+    );
+}
+
+.HS-colorblind .HS-rater-button.HS-rater-foe {
+    background-color: #C8850E;
+    background-image: -webkit-gradient(
+        linear,
+        left bottom,
+        left top,
+        color-stop(0.16, #B8780C),
+        color-stop(0.84, #C8850E)
+    );
+    background-image: -moz-linear-gradient(
+        center bottom,
+        #B8780C 16%,
+        #C8850E 84%
+    );
+}
+
+.HS-colorblind .HS-foaf-friend .HS-foaf-start,
+.HS-colorblind .HS-foaf-foe    .HS-foaf-start {
+    background-color: #2B6CB0;
+    background-image: -webkit-gradient(
+        linear,
+        left bottom,
+        left top,
+        color-stop(0.16, #2563A8),
+        color-stop(0.84, #2B6CB0)
+    );
+    background-image: -moz-linear-gradient(
+        center bottom,
+        #2563A8 16%,
+        #2B6CB0 84%
+    );
+}
+.HS-colorblind .HS-foaf-friend .HS-foaf-end {
+    background-color: #215A91;
+    background-image: -webkit-gradient(
+        linear,
+        left bottom,
+        left top,
+        color-stop(0.16, #1D4F80),
+        color-stop(0.84, #215A91)
+    );
+    background-image: -moz-linear-gradient(
+        center bottom,
+        #1D4F80 16%,
+        #215A91 84%
+    );
+}
+.HS-colorblind .HS-foaf-foe .HS-foaf-end {
+    background-color: #A06A0A;
+    background-image: -webkit-gradient(
+        linear,
+        left bottom,
+        left top,
+        color-stop(0.16, #8F5E09),
+        color-stop(0.84, #A06A0A)
+    );
+    background-image: -moz-linear-gradient(
+        center bottom,
+        #8F5E09 16%,
+        #A06A0A 84%
+    );
+}

--- a/client/chrome/client.js
+++ b/client/chrome/client.js
@@ -29,6 +29,7 @@
           this.auth_token = (response != null ? response.auth_token : void 0) || null;
           this.stored_username = (response != null ? response.username : void 0) || null;
           this.verified = !!this.auth_token;
+          this.loadColorblindPref();
           return callback();
         });
       } else if (typeof browser !== 'undefined' && (typeof browser !== "undefined" && browser !== null ? (ref1 = browser.runtime) != null ? ref1.sendMessage : void 0 : void 0)) {
@@ -38,6 +39,7 @@
           this.auth_token = (response != null ? response.auth_token : void 0) || null;
           this.stored_username = (response != null ? response.username : void 0) || null;
           this.verified = !!this.auth_token;
+          this.loadColorblindPref();
           return callback();
         });
       } else {
@@ -80,6 +82,36 @@
         return chrome.runtime.sendMessage(msg);
       } else if (typeof browser !== 'undefined' && (typeof browser !== "undefined" && browser !== null ? (ref1 = browser.runtime) != null ? ref1.sendMessage : void 0 : void 0)) {
         return browser.runtime.sendMessage(msg);
+      }
+    }
+
+    loadColorblindPref() {
+      var ref, ref1, ref2, ref3, sendMsg, storageApi;
+      sendMsg = (typeof chrome !== "undefined" && chrome !== null ? (ref = chrome.runtime) != null ? ref.sendMessage : void 0 : void 0) || (typeof browser !== 'undefined' && (typeof browser !== "undefined" && browser !== null ? (ref1 = browser.runtime) != null ? ref1.sendMessage : void 0 : void 0));
+      if (!sendMsg) {
+        return;
+      }
+      chrome.runtime.sendMessage({
+        action: 'getColorblind'
+      }, (response) => {
+        if (response != null ? response.colorblind : void 0) {
+          return $('body').addClass('HS-colorblind');
+        } else {
+          return $('body').removeClass('HS-colorblind');
+        }
+      });
+      // Listen for storage changes so popup toggle takes effect immediately
+      storageApi = (typeof chrome !== "undefined" && chrome !== null ? (ref2 = chrome.storage) != null ? ref2.onChanged : void 0 : void 0) || (typeof browser !== 'undefined' && (typeof browser !== "undefined" && browser !== null ? (ref3 = browser.storage) != null ? ref3.onChanged : void 0 : void 0));
+      if (storageApi) {
+        return chrome.storage.onChanged.addListener((changes) => {
+          if (changes.hs_colorblind != null) {
+            if (changes.hs_colorblind.newValue) {
+              return $('body').addClass('HS-colorblind');
+            } else {
+              return $('body').removeClass('HS-colorblind');
+            }
+          }
+        });
       }
     }
 

--- a/client/chrome/manifest.json
+++ b/client/chrome/manifest.json
@@ -36,6 +36,7 @@
   ],
   "action": {
     "default_icon": "icon.png",
-    "default_title": "Hacker Smacker"
+    "default_title": "Hacker Smacker",
+    "default_popup": "popup.html"
   }
 }

--- a/client/chrome/popup.html
+++ b/client/chrome/popup.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body {
+    width: 220px;
+    padding: 12px 14px;
+    margin: 0;
+    font-family: Verdana, Geneva, sans-serif;
+    font-size: 12px;
+    color: #333;
+    background: #F6F6EF;
+}
+h3 {
+    margin: 0 0 10px;
+    font-size: 13px;
+    color: #2C2416;
+}
+label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    padding: 6px 0;
+}
+input[type="checkbox"] {
+    margin: 0;
+    cursor: pointer;
+}
+.description {
+    font-size: 10px;
+    color: #828282;
+    margin-top: 4px;
+    line-height: 1.4;
+}
+</style>
+</head>
+<body>
+<h3>Hacker Smacker</h3>
+<label>
+    <input type="checkbox" id="colorblind">
+    Colorblind mode
+</label>
+<div class="description">Uses blue/gold instead of green/red</div>
+
+<script>
+(function() {
+    var storage = (chrome && chrome.storage && chrome.storage.local) ||
+                  (typeof browser !== 'undefined' && browser && browser.storage && browser.storage.local);
+    var checkbox = document.getElementById('colorblind');
+
+    storage.get(['hs_colorblind'], function(data) {
+        checkbox.checked = !!(data && data.hs_colorblind);
+    });
+
+    checkbox.addEventListener('change', function() {
+        storage.set({ hs_colorblind: checkbox.checked });
+    });
+})();
+</script>
+</body>
+</html>

--- a/client/common/background.coffee
+++ b/client/common/background.coffee
@@ -45,6 +45,17 @@ handleMessage = (request, sender, sendResponse) ->
                 sendResponse { success: true }
             return true
 
+        when 'getColorblind'
+            storage.get ['hs_colorblind'], (data) ->
+                sendResponse
+                    colorblind: !!data?.hs_colorblind
+            return true
+
+        when 'setColorblind'
+            storage.set { hs_colorblind: !!request.enabled }, ->
+                sendResponse { success: true }
+            return true
+
 if chrome?.runtime?.onMessage
     chrome.runtime.onMessage.addListener handleMessage
 else if typeof browser isnt 'undefined' and browser?.runtime?.onMessage

--- a/client/common/background.js
+++ b/client/common/background.js
@@ -58,6 +58,22 @@
           });
         });
         return true;
+      case 'getColorblind':
+        storage.get(['hs_colorblind'], function(data) {
+          return sendResponse({
+            colorblind: !!(data != null ? data.hs_colorblind : void 0)
+          });
+        });
+        return true;
+      case 'setColorblind':
+        storage.set({
+          hs_colorblind: !!request.enabled
+        }, function() {
+          return sendResponse({
+            success: true
+          });
+        });
+        return true;
     }
   };
 

--- a/client/common/client.coffee
+++ b/client/common/client.coffee
@@ -20,12 +20,14 @@ class window.HSGraph
                 @auth_token = response?.auth_token or null
                 @stored_username = response?.username or null
                 @verified = !!@auth_token
+                @loadColorblindPref()
                 callback()
         else if typeof browser isnt 'undefined' and browser?.runtime?.sendMessage
             browser.runtime.sendMessage { action: 'getAuthToken' }, (response) =>
                 @auth_token = response?.auth_token or null
                 @stored_username = response?.username or null
                 @verified = !!@auth_token
+                @loadColorblindPref()
                 callback()
         else
             callback()
@@ -51,6 +53,24 @@ class window.HSGraph
             chrome.runtime.sendMessage msg
         else if typeof browser isnt 'undefined' and browser?.runtime?.sendMessage
             browser.runtime.sendMessage msg
+
+    loadColorblindPref: ->
+        sendMsg = chrome?.runtime?.sendMessage or (typeof browser isnt 'undefined' and browser?.runtime?.sendMessage)
+        return unless sendMsg
+        chrome.runtime.sendMessage { action: 'getColorblind' }, (response) =>
+            if response?.colorblind
+                $('body').addClass 'HS-colorblind'
+            else
+                $('body').removeClass 'HS-colorblind'
+        # Listen for storage changes so popup toggle takes effect immediately
+        storageApi = chrome?.storage?.onChanged or (typeof browser isnt 'undefined' and browser?.storage?.onChanged)
+        if storageApi
+            chrome.storage.onChanged.addListener (changes) =>
+                if changes.hs_colorblind?
+                    if changes.hs_colorblind.newValue
+                        $('body').addClass 'HS-colorblind'
+                    else
+                        $('body').removeClass 'HS-colorblind'
 
     decorateComments: ->
         found = @findCurrentUser()

--- a/client/common/client.css
+++ b/client/common/client.css
@@ -190,3 +190,86 @@
         #C2483B 84%
     );
 }
+
+/* ========================== */
+/* = Colorblind Mode         = */
+/* ========================== */
+
+.HS-colorblind .HS-rater-button.HS-rater-friend {
+    background-color: #2B6CB0;
+    background-image: -webkit-gradient(
+        linear,
+        left bottom,
+        left top,
+        color-stop(0.16, #2563A8),
+        color-stop(0.84, #2B6CB0)
+    );
+    background-image: -moz-linear-gradient(
+        center bottom,
+        #2563A8 16%,
+        #2B6CB0 84%
+    );
+}
+
+.HS-colorblind .HS-rater-button.HS-rater-foe {
+    background-color: #C8850E;
+    background-image: -webkit-gradient(
+        linear,
+        left bottom,
+        left top,
+        color-stop(0.16, #B8780C),
+        color-stop(0.84, #C8850E)
+    );
+    background-image: -moz-linear-gradient(
+        center bottom,
+        #B8780C 16%,
+        #C8850E 84%
+    );
+}
+
+.HS-colorblind .HS-foaf-friend .HS-foaf-start,
+.HS-colorblind .HS-foaf-foe    .HS-foaf-start {
+    background-color: #2B6CB0;
+    background-image: -webkit-gradient(
+        linear,
+        left bottom,
+        left top,
+        color-stop(0.16, #2563A8),
+        color-stop(0.84, #2B6CB0)
+    );
+    background-image: -moz-linear-gradient(
+        center bottom,
+        #2563A8 16%,
+        #2B6CB0 84%
+    );
+}
+.HS-colorblind .HS-foaf-friend .HS-foaf-end {
+    background-color: #215A91;
+    background-image: -webkit-gradient(
+        linear,
+        left bottom,
+        left top,
+        color-stop(0.16, #1D4F80),
+        color-stop(0.84, #215A91)
+    );
+    background-image: -moz-linear-gradient(
+        center bottom,
+        #1D4F80 16%,
+        #215A91 84%
+    );
+}
+.HS-colorblind .HS-foaf-foe .HS-foaf-end {
+    background-color: #A06A0A;
+    background-image: -webkit-gradient(
+        linear,
+        left bottom,
+        left top,
+        color-stop(0.16, #8F5E09),
+        color-stop(0.84, #A06A0A)
+    );
+    background-image: -moz-linear-gradient(
+        center bottom,
+        #8F5E09 16%,
+        #A06A0A 84%
+    );
+}

--- a/client/common/client.js
+++ b/client/common/client.js
@@ -29,6 +29,7 @@
           this.auth_token = (response != null ? response.auth_token : void 0) || null;
           this.stored_username = (response != null ? response.username : void 0) || null;
           this.verified = !!this.auth_token;
+          this.loadColorblindPref();
           return callback();
         });
       } else if (typeof browser !== 'undefined' && (typeof browser !== "undefined" && browser !== null ? (ref1 = browser.runtime) != null ? ref1.sendMessage : void 0 : void 0)) {
@@ -38,6 +39,7 @@
           this.auth_token = (response != null ? response.auth_token : void 0) || null;
           this.stored_username = (response != null ? response.username : void 0) || null;
           this.verified = !!this.auth_token;
+          this.loadColorblindPref();
           return callback();
         });
       } else {
@@ -80,6 +82,36 @@
         return chrome.runtime.sendMessage(msg);
       } else if (typeof browser !== 'undefined' && (typeof browser !== "undefined" && browser !== null ? (ref1 = browser.runtime) != null ? ref1.sendMessage : void 0 : void 0)) {
         return browser.runtime.sendMessage(msg);
+      }
+    }
+
+    loadColorblindPref() {
+      var ref, ref1, ref2, ref3, sendMsg, storageApi;
+      sendMsg = (typeof chrome !== "undefined" && chrome !== null ? (ref = chrome.runtime) != null ? ref.sendMessage : void 0 : void 0) || (typeof browser !== 'undefined' && (typeof browser !== "undefined" && browser !== null ? (ref1 = browser.runtime) != null ? ref1.sendMessage : void 0 : void 0));
+      if (!sendMsg) {
+        return;
+      }
+      chrome.runtime.sendMessage({
+        action: 'getColorblind'
+      }, (response) => {
+        if (response != null ? response.colorblind : void 0) {
+          return $('body').addClass('HS-colorblind');
+        } else {
+          return $('body').removeClass('HS-colorblind');
+        }
+      });
+      // Listen for storage changes so popup toggle takes effect immediately
+      storageApi = (typeof chrome !== "undefined" && chrome !== null ? (ref2 = chrome.storage) != null ? ref2.onChanged : void 0 : void 0) || (typeof browser !== 'undefined' && (typeof browser !== "undefined" && browser !== null ? (ref3 = browser.storage) != null ? ref3.onChanged : void 0 : void 0));
+      if (storageApi) {
+        return chrome.storage.onChanged.addListener((changes) => {
+          if (changes.hs_colorblind != null) {
+            if (changes.hs_colorblind.newValue) {
+              return $('body').addClass('HS-colorblind');
+            } else {
+              return $('body').removeClass('HS-colorblind');
+            }
+          }
+        });
       }
     }
 

--- a/client/common/popup.html
+++ b/client/common/popup.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body {
+    width: 220px;
+    padding: 12px 14px;
+    margin: 0;
+    font-family: Verdana, Geneva, sans-serif;
+    font-size: 12px;
+    color: #333;
+    background: #F6F6EF;
+}
+h3 {
+    margin: 0 0 10px;
+    font-size: 13px;
+    color: #2C2416;
+}
+label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    padding: 6px 0;
+}
+input[type="checkbox"] {
+    margin: 0;
+    cursor: pointer;
+}
+.description {
+    font-size: 10px;
+    color: #828282;
+    margin-top: 4px;
+    line-height: 1.4;
+}
+</style>
+</head>
+<body>
+<h3>Hacker Smacker</h3>
+<label>
+    <input type="checkbox" id="colorblind">
+    Colorblind mode
+</label>
+<div class="description">Uses blue/gold instead of green/red</div>
+
+<script>
+(function() {
+    var storage = (chrome && chrome.storage && chrome.storage.local) ||
+                  (typeof browser !== 'undefined' && browser && browser.storage && browser.storage.local);
+    var checkbox = document.getElementById('colorblind');
+
+    storage.get(['hs_colorblind'], function(data) {
+        checkbox.checked = !!(data && data.hs_colorblind);
+    });
+
+    checkbox.addEventListener('change', function() {
+        storage.set({ hs_colorblind: checkbox.checked });
+    });
+})();
+</script>
+</body>
+</html>

--- a/client/firefox/manifest.json
+++ b/client/firefox/manifest.json
@@ -47,11 +47,12 @@
       }
     }
   },
-  "page_action": {
+  "browser_action": {
     "default_icon": {
       "16": "data/icon-16.png",
       "32": "data/icon-32.png"
     },
-    "default_title": "Hacker Smacker"
+    "default_title": "Hacker Smacker",
+    "default_popup": "data/popup.html"
   }
 }

--- a/client/safari/WebExtension/background.js
+++ b/client/safari/WebExtension/background.js
@@ -58,6 +58,22 @@
           });
         });
         return true;
+      case 'getColorblind':
+        storage.get(['hs_colorblind'], function(data) {
+          return sendResponse({
+            colorblind: !!(data != null ? data.hs_colorblind : void 0)
+          });
+        });
+        return true;
+      case 'setColorblind':
+        storage.set({
+          hs_colorblind: !!request.enabled
+        }, function() {
+          return sendResponse({
+            success: true
+          });
+        });
+        return true;
     }
   };
 

--- a/client/safari/WebExtension/client.css
+++ b/client/safari/WebExtension/client.css
@@ -190,3 +190,86 @@
         #C2483B 84%
     );
 }
+
+/* ========================== */
+/* = Colorblind Mode         = */
+/* ========================== */
+
+.HS-colorblind .HS-rater-button.HS-rater-friend {
+    background-color: #2B6CB0;
+    background-image: -webkit-gradient(
+        linear,
+        left bottom,
+        left top,
+        color-stop(0.16, #2563A8),
+        color-stop(0.84, #2B6CB0)
+    );
+    background-image: -moz-linear-gradient(
+        center bottom,
+        #2563A8 16%,
+        #2B6CB0 84%
+    );
+}
+
+.HS-colorblind .HS-rater-button.HS-rater-foe {
+    background-color: #C8850E;
+    background-image: -webkit-gradient(
+        linear,
+        left bottom,
+        left top,
+        color-stop(0.16, #B8780C),
+        color-stop(0.84, #C8850E)
+    );
+    background-image: -moz-linear-gradient(
+        center bottom,
+        #B8780C 16%,
+        #C8850E 84%
+    );
+}
+
+.HS-colorblind .HS-foaf-friend .HS-foaf-start,
+.HS-colorblind .HS-foaf-foe    .HS-foaf-start {
+    background-color: #2B6CB0;
+    background-image: -webkit-gradient(
+        linear,
+        left bottom,
+        left top,
+        color-stop(0.16, #2563A8),
+        color-stop(0.84, #2B6CB0)
+    );
+    background-image: -moz-linear-gradient(
+        center bottom,
+        #2563A8 16%,
+        #2B6CB0 84%
+    );
+}
+.HS-colorblind .HS-foaf-friend .HS-foaf-end {
+    background-color: #215A91;
+    background-image: -webkit-gradient(
+        linear,
+        left bottom,
+        left top,
+        color-stop(0.16, #1D4F80),
+        color-stop(0.84, #215A91)
+    );
+    background-image: -moz-linear-gradient(
+        center bottom,
+        #1D4F80 16%,
+        #215A91 84%
+    );
+}
+.HS-colorblind .HS-foaf-foe .HS-foaf-end {
+    background-color: #A06A0A;
+    background-image: -webkit-gradient(
+        linear,
+        left bottom,
+        left top,
+        color-stop(0.16, #8F5E09),
+        color-stop(0.84, #A06A0A)
+    );
+    background-image: -moz-linear-gradient(
+        center bottom,
+        #8F5E09 16%,
+        #A06A0A 84%
+    );
+}

--- a/client/safari/WebExtension/client.js
+++ b/client/safari/WebExtension/client.js
@@ -29,6 +29,7 @@
           this.auth_token = (response != null ? response.auth_token : void 0) || null;
           this.stored_username = (response != null ? response.username : void 0) || null;
           this.verified = !!this.auth_token;
+          this.loadColorblindPref();
           return callback();
         });
       } else if (typeof browser !== 'undefined' && (typeof browser !== "undefined" && browser !== null ? (ref1 = browser.runtime) != null ? ref1.sendMessage : void 0 : void 0)) {
@@ -38,6 +39,7 @@
           this.auth_token = (response != null ? response.auth_token : void 0) || null;
           this.stored_username = (response != null ? response.username : void 0) || null;
           this.verified = !!this.auth_token;
+          this.loadColorblindPref();
           return callback();
         });
       } else {
@@ -80,6 +82,36 @@
         return chrome.runtime.sendMessage(msg);
       } else if (typeof browser !== 'undefined' && (typeof browser !== "undefined" && browser !== null ? (ref1 = browser.runtime) != null ? ref1.sendMessage : void 0 : void 0)) {
         return browser.runtime.sendMessage(msg);
+      }
+    }
+
+    loadColorblindPref() {
+      var ref, ref1, ref2, ref3, sendMsg, storageApi;
+      sendMsg = (typeof chrome !== "undefined" && chrome !== null ? (ref = chrome.runtime) != null ? ref.sendMessage : void 0 : void 0) || (typeof browser !== 'undefined' && (typeof browser !== "undefined" && browser !== null ? (ref1 = browser.runtime) != null ? ref1.sendMessage : void 0 : void 0));
+      if (!sendMsg) {
+        return;
+      }
+      chrome.runtime.sendMessage({
+        action: 'getColorblind'
+      }, (response) => {
+        if (response != null ? response.colorblind : void 0) {
+          return $('body').addClass('HS-colorblind');
+        } else {
+          return $('body').removeClass('HS-colorblind');
+        }
+      });
+      // Listen for storage changes so popup toggle takes effect immediately
+      storageApi = (typeof chrome !== "undefined" && chrome !== null ? (ref2 = chrome.storage) != null ? ref2.onChanged : void 0 : void 0) || (typeof browser !== 'undefined' && (typeof browser !== "undefined" && browser !== null ? (ref3 = browser.storage) != null ? ref3.onChanged : void 0 : void 0));
+      if (storageApi) {
+        return chrome.storage.onChanged.addListener((changes) => {
+          if (changes.hs_colorblind != null) {
+            if (changes.hs_colorblind.newValue) {
+              return $('body').addClass('HS-colorblind');
+            } else {
+              return $('body').removeClass('HS-colorblind');
+            }
+          }
+        });
       }
     }
 

--- a/client/safari/WebExtension/manifest.json
+++ b/client/safari/WebExtension/manifest.json
@@ -37,11 +37,12 @@
     "https://www.hackersmacker.org/",
     "storage"
   ],
-  "page_action": {
+  "browser_action": {
     "default_icon": {
       "48": "images/icon-48.png",
       "64": "images/icon-64.png"
     },
-    "default_title": "Hacker Smacker"
+    "default_title": "Hacker Smacker",
+    "default_popup": "popup.html"
   }
 }

--- a/client/safari/WebExtension/popup.html
+++ b/client/safari/WebExtension/popup.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body {
+    width: 220px;
+    padding: 12px 14px;
+    margin: 0;
+    font-family: Verdana, Geneva, sans-serif;
+    font-size: 12px;
+    color: #333;
+    background: #F6F6EF;
+}
+h3 {
+    margin: 0 0 10px;
+    font-size: 13px;
+    color: #2C2416;
+}
+label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    padding: 6px 0;
+}
+input[type="checkbox"] {
+    margin: 0;
+    cursor: pointer;
+}
+.description {
+    font-size: 10px;
+    color: #828282;
+    margin-top: 4px;
+    line-height: 1.4;
+}
+</style>
+</head>
+<body>
+<h3>Hacker Smacker</h3>
+<label>
+    <input type="checkbox" id="colorblind">
+    Colorblind mode
+</label>
+<div class="description">Uses blue/gold instead of green/red</div>
+
+<script>
+(function() {
+    var storage = (chrome && chrome.storage && chrome.storage.local) ||
+                  (typeof browser !== 'undefined' && browser && browser.storage && browser.storage.local);
+    var checkbox = document.getElementById('colorblind');
+
+    storage.get(['hs_colorblind'], function(data) {
+        checkbox.checked = !!(data && data.hs_colorblind);
+    });
+
+    checkbox.addEventListener('change', function() {
+        storage.set({ hs_colorblind: checkbox.checked });
+    });
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds a toolbar popup with a **colorblind mode** checkbox that swaps green/red orbs for a cividis-inspired blue/gold palette
- Setting persists in extension storage and applies instantly via `storage.onChanged` listener (no page reload needed)
- Updates all three browser extensions (Chrome, Firefox, Safari) with popup, CSS color variants, and manifest changes

## Test plan
- [ ] Load Chrome extension unpacked from `client/chrome/`
- [ ] Click the extension icon — popup appears with "Colorblind mode" checkbox
- [ ] Enable colorblind mode — friend orbs turn blue, foe orbs turn gold immediately
- [ ] Reload page — setting persists (orbs remain blue/gold)
- [ ] Disable toggle — orbs revert to green/red
- [ ] Verify FoaF pills also change colors

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)